### PR TITLE
Fix ErrorExtension for Behat 3 and phpspec 2

### DIFF
--- a/src/Extension/ErrorExtension/src/Observer/ErrorObserver.php
+++ b/src/Extension/ErrorExtension/src/Observer/ErrorObserver.php
@@ -2,7 +2,9 @@
 
 namespace RMiller\ErrorExtension\Observer;
 
+use Behat\Testwork\Call\Exception\FatalThrowableError;
+
 interface ErrorObserver
 {
-    public function notify(array $error);
+    public function notify(FatalThrowableError $error);
 }

--- a/src/Extension/ErrorExtension/src/Observer/ErrorObservers.php
+++ b/src/Extension/ErrorExtension/src/Observer/ErrorObservers.php
@@ -8,7 +8,7 @@ class ErrorObservers implements \IteratorAggregate
 
     public function __construct(array $observers = [])
     {
-        foreach($observers as $observer) {
+        foreach ($observers as $observer) {
             if ($observer instanceof ErrorObserver) {
                 continue;
             }

--- a/src/Extension/ErrorExtension/src/Tester/ErrorTester.php
+++ b/src/Extension/ErrorExtension/src/Tester/ErrorTester.php
@@ -3,7 +3,6 @@
 namespace Rmiller\ErrorExtension\Tester;
 
 use Behat\Testwork\Environment\Environment;
-use Behat\Testwork\Output\Printer\OutputPrinter;
 use Behat\Testwork\Specification\SpecificationIterator;
 use Behat\Testwork\Tester\Result\TestResult;
 use Behat\Testwork\Tester\Setup\Setup;
@@ -77,7 +76,7 @@ class ErrorTester implements SuiteTester
 
     private function turnOffErrorDisplayingIfNotVerbose()
     {
-        if ($this->output->getVerbosity() == OutputPrinter::VERBOSITY_NORMAL) {
+        if ($this->output->getVerbosity() === OutputInterface::OUTPUT_NORMAL) {
             error_reporting(E_ALL & ~E_ERROR);
         }
     }

--- a/src/Extension/ErrorExtension/src/services.xml
+++ b/src/Extension/ErrorExtension/src/services.xml
@@ -9,7 +9,7 @@
             <argument/>
             <argument type="service" id="cli.output"/>
             <argument type="collection" />
-            <tag name="tester.suite.wrapper" priority="-9999"/>
+            <tag name="tester.step.wrapper" priority="-9999"/>
         </service>
 
     </services>

--- a/src/Extension/ExemplifyExtension/features/bootstrap/AppicationTester.php
+++ b/src/Extension/ExemplifyExtension/features/bootstrap/AppicationTester.php
@@ -1,0 +1,125 @@
+<?php
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\StreamOutput;
+
+/**
+ * A console application tester heavily inspired by/proudly stolen from \Symfony\Component\Console\Tester\ApplicationTester.
+ */
+class ApplicationTester
+{
+    /**
+     * @var Application $application
+     */
+    private $application;
+
+    /**
+     * @var StringInput $input
+     */
+    private $input;
+
+    /**
+     * @var StreamOutput $output
+     */
+    private $output;
+
+    /**
+     * @var resource $inputStream
+     */
+    private $inputStream;
+
+    /**
+     * @param Application $application
+     */
+    public function __construct(Application $application)
+    {
+        $this->application = $application;
+    }
+
+    /**
+     * @param string $input
+     * @param array  $options
+     *
+     * @return integer
+     */
+    public function run($input, array $options = array())
+    {
+        if (isset($options['interactive']) && $options['interactive']) {
+            $this->input = new InteractiveStringInput($input);
+        } else {
+            $this->input = new StringInput($input);
+            $this->input->setInteractive(false);
+        }
+
+        $this->output = new StreamOutput(fopen('php://memory', 'w', false));
+        if (isset($options['decorated'])) {
+            $this->output->setDecorated($options['decorated']);
+        }
+        if (isset($options['verbosity'])) {
+            $this->output->setVerbosity($options['verbosity']);
+        }
+
+        $inputStream = $this->getInputStream();
+        rewind($inputStream);
+        $this->application->getHelperSet()
+            ->get('question')
+            ->setInputStream($inputStream);
+
+        return $this->application->run($this->input, $this->output);
+    }
+
+    /**
+     * @param boolean
+     *
+     * @return string
+     */
+    public function getDisplay($normalize = false)
+    {
+        rewind($this->output->getStream());
+
+        $display = stream_get_contents($this->output->getStream());
+
+        if ($normalize) {
+            $display = str_replace(PHP_EOL, "\n", $display);
+        }
+
+        return $display;
+    }
+
+    /**
+     * @return InputInterface
+     */
+    public function getInput()
+    {
+        return $this->input;
+    }
+
+    /**
+     * @return OutputInterface
+     */
+    public function getOutput()
+    {
+        return $this->output;
+    }
+
+    /**
+     * @param string $input
+     */
+    public function putToInputStream($input)
+    {
+        fputs($this->getInputStream(), $input);
+    }
+
+    /**
+     * @return resource
+     */
+    private function getInputStream()
+    {
+        if (null === $this->inputStream) {
+            $this->inputStream = fopen('php://memory', 'r+', false);
+        }
+
+        return $this->inputStream;
+    }
+}

--- a/src/Extension/ExemplifyExtension/features/bootstrap/FeatureContext.php
+++ b/src/Extension/ExemplifyExtension/features/bootstrap/FeatureContext.php
@@ -27,7 +27,6 @@ class FeatureContext implements Context, SnippetAcceptingContext
      */
     public function createWorkDir()
     {
-
         $this->workDir = sprintf(
             '%s/%s/',
             sys_get_temp_dir(),
@@ -84,7 +83,7 @@ class FeatureContext implements Context, SnippetAcceptingContext
      */
     private function createApplicationTester()
     {
-        file_put_contents('phpspec.yml','extensions: [RMiller\ExemplifyExtension\ExemplifyExtension]');
+        file_put_contents('phpspec.yml', 'extensions: [RMiller\ExemplifyExtension\ExemplifyExtension]');
         $application = new Application('2.1-dev');
         $application->setAutoExit(false);
 

--- a/src/Extension/ExemplifyExtension/features/bootstrap/FeatureContext.php
+++ b/src/Extension/ExemplifyExtension/features/bootstrap/FeatureContext.php
@@ -4,7 +4,6 @@ use Behat\Behat\Tester\Exception\PendingException;
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\Gherkin\Node\PyStringNode;
-use Console\ApplicationTester;
 use PhpSpec\Console\Application;
 use Symfony\Component\Filesystem\Filesystem;
 

--- a/src/Extension/ExemplifyExtension/src/Command/ExemplifyCommand.php
+++ b/src/Extension/ExemplifyExtension/src/Command/ExemplifyCommand.php
@@ -7,6 +7,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
 
 class ExemplifyCommand extends Command
 {
@@ -54,7 +55,7 @@ EOF
 
         $container->get('code_generator')->generate($resource, 'specification_method', [
             'method' => $method,
-            'type' => $this->confirmMethodType($output),
+            'type' => $this->confirmMethodType($input, $output),
         ]);
     }
 
@@ -79,16 +80,18 @@ EOF
     /**
      * @param OutputInterface $output
      */
-    private function confirmMethodType(OutputInterface $output)
+    private function confirmMethodType(InputInterface $input, OutputInterface $output)
     {
         $formattedMethodTypes = ['instance method','named constructor', 'static method'];
-        $methodTypes = ['instance-method', 'named-constructor', 'static-method'];
 
-        return $methodTypes[$this->getHelper('dialog')->select(
+        return str_replace(' ', '-', $this->getHelper('question')->ask(
+            $input,
             $output,
-            'Please select the method type (defaults to instance method)',
-            $formattedMethodTypes,
-            0
-        )];
+            new ChoiceQuestion(
+                'Please select the method type (defaults to instance method)',
+                $formattedMethodTypes,
+                0
+            )
+        ));
     }
 }

--- a/src/Extension/PhpSpecExtension/src/ErrorObserver/MissingMethodErrorObserver.php
+++ b/src/Extension/PhpSpecExtension/src/ErrorObserver/MissingMethodErrorObserver.php
@@ -2,6 +2,7 @@
 
 namespace RMiller\PhpSpecExtension\ErrorObserver;
 
+use Behat\Testwork\Call\Exception\FatalThrowableError;
 use RMiller\ErrorExtension\Observer\ErrorObserver;
 use RMiller\PhpSpecExtension\Process\ExemplifyRunner;
 
@@ -14,14 +15,15 @@ class MissingMethodErrorObserver implements ErrorObserver
         $this->exemplifyRunner = $exemplifyRunner;
     }
 
-    public function notify(array $error)
+    public function notify(FatalThrowableError $error)
     {
-        if (strpos($error['message'], 'Call to undefined method') === false) {
+        if (strpos($error->getMessage(), 'Call to undefined method') === false) {
             return;
         }
 
-        $missing = trim(substr($error['message'], strlen('Call to undefined method')));
-        list ($class, $method) = explode('::', $missing);
+        $missing = trim(substr($error->getMessage(), strlen('Fatal error: Call to undefined method')));
+        list($class, $method) = explode('::', $missing);
+
         $this->exemplifyRunner->runExemplifyCommand($class, substr($method, 0, -2));
     }
 }

--- a/src/Extension/PhpSpecExtension/src/Process/CommandRunner/PassthruCommandRunner.php
+++ b/src/Extension/PhpSpecExtension/src/Process/CommandRunner/PassthruCommandRunner.php
@@ -14,7 +14,8 @@ class PassthruCommandRunner implements CommandRunner
     /**
      * @param CliFunctionChecker $functionChecker
      */
-    public function __construct(CliFunctionChecker $functionChecker) {
+    public function __construct(CliFunctionChecker $functionChecker)
+    {
         $this->functionChecker = $functionChecker;
     }
 

--- a/src/Extension/PhpSpecExtension/src/Process/CommandRunner/PcntlCommandRunner.php
+++ b/src/Extension/PhpSpecExtension/src/Process/CommandRunner/PcntlCommandRunner.php
@@ -14,7 +14,8 @@ class PcntlCommandRunner implements CommandRunner
     /**
      * @param CliFunctionChecker $functionChecker
      */
-    public function __construct(CliFunctionChecker $functionChecker) {
+    public function __construct(CliFunctionChecker $functionChecker)
+    {
         $this->functionChecker = $functionChecker;
     }
 

--- a/src/Extension/PhpSpecExtension/src/Tester/PhpSpecTester.php
+++ b/src/Extension/PhpSpecExtension/src/Tester/PhpSpecTester.php
@@ -75,8 +75,7 @@ class PhpSpecTester implements SuiteTester
      */
     public function setUp(Environment $env, SpecificationIterator $iterator, $skip)
     {
-        spl_autoload_register(function($class) {
-
+        spl_autoload_register(function ($class) {
             $errorMessages = [
                 $class .' was not found.'
             ];
@@ -96,7 +95,6 @@ class PhpSpecTester implements SuiteTester
                 $this->output->writeln('');
                 $this->specRunner->runDescCommand($class);
             }
-
         }, true, false);
 
         return $this->baseTester->setUp($env, $iterator, $skip);

--- a/src/Extension/PhpSpecRunExtension/src/CommandSubscriber.php
+++ b/src/Extension/PhpSpecRunExtension/src/CommandSubscriber.php
@@ -14,7 +14,7 @@ class CommandSubscriber implements EventSubscriberInterface
     private $commands;
     private $io;
 
-    function __construct(CompositeRunRunner $runRunner, IO $io, array $commands)
+    public function __construct(CompositeRunRunner $runRunner, IO $io, array $commands)
     {
         $this->runRunner = $runRunner;
         $this->commands = $commands;

--- a/src/Extension/PhpSpecRunExtension/src/PhpSpecRunExtension.php
+++ b/src/Extension/PhpSpecRunExtension/src/PhpSpecRunExtension.php
@@ -20,7 +20,6 @@ class PhpSpecRunExtension implements ExtensionInterface
     public function load(ServiceContainer $container)
     {
         $container->setShared('rmiller.run_runner', function ($c) {
-
             $params = $c->getParam('rerunner', []);
             $phpspecPath = isset($params['path']) ? $params['path'] : 'bin/phpspec';
             $phpspecConfig = isset($params['config']) ? $params['config'] : null;

--- a/src/Extension/PhpSpecRunExtension/src/Process/CommandRunner/PassthruCommandRunner.php
+++ b/src/Extension/PhpSpecRunExtension/src/Process/CommandRunner/PassthruCommandRunner.php
@@ -14,7 +14,8 @@ class PassthruCommandRunner implements CommandRunner
     /**
      * @param CliFunctionChecker $functionChecker
      */
-    public function __construct(CliFunctionChecker $functionChecker) {
+    public function __construct(CliFunctionChecker $functionChecker)
+    {
         $this->functionChecker = $functionChecker;
     }
 

--- a/src/Extension/PhpSpecRunExtension/src/Process/CommandRunner/PcntlCommandRunner.php
+++ b/src/Extension/PhpSpecRunExtension/src/Process/CommandRunner/PcntlCommandRunner.php
@@ -14,7 +14,8 @@ class PcntlCommandRunner implements CommandRunner
     /**
      * @param CliFunctionChecker $functionChecker
      */
-    public function __construct(CliFunctionChecker $functionChecker) {
+    public function __construct(CliFunctionChecker $functionChecker)
+    {
         $this->functionChecker = $functionChecker;
     }
 


### PR DESCRIPTION
Hello,

This PR fix problems with ErrorExtension on master version of BehatSpec (related to https://github.com/richardmiller/ErrorExtension/issues/2).

It also includes:

- changes from https://github.com/richardmiller/ExemplifyExtension/pull/4 and https://github.com/richardmiller/ExemplifyExtension/pull/5
- remove deprecated OutputPrinter https://github.com/richardmiller/ErrorExtension/pull/3
