### PR TITLE
v0.3.2 - Final Fix extension versions + Fix PhpSpec 2 dependency v0.3.2 + Fix Minimum stability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,13 @@
             "homepage":  "http://richardmiller.co.uk"
         }
     ],
-
     "require": {
         "php": ">=5.4",
-        "phpspec/phpspec": "<3.0",
-        "rmiller/error-extension": "~0.1||<0.4",
-        "rmiller/phpspec-extension": "~0.2||<0.4",
-        "rmiller/exemplify-extension": "~0.2||<0.4",
-        "rmiller/phpspec-run-extension": "~0.2||<0.4"
+        "phpspec/phpspec": "~2.0",
+        "rmiller/error-extension": "<0.4",
+        "rmiller/phpspec-extension": "<0.4",
+        "rmiller/exemplify-extension": "<0.4",
+        "rmiller/phpspec-run-extension": "<0.4"
     },
 
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,5 @@
             "RMiller\\BehatSpec\\": "src/"
         }
     },
-    "minimum-stability": "dev"
+    "minimum-stability": "stable"
 }


### PR DESCRIPTION
This PR fixes : 
- Extension versions (previous setting would still install `0.4.1+` unless specified manually.
- The `phpspec <3.0` somehow slipped as I was meaning to set it to `~2.0`.
- Set `minimum-stability` to `stable` as this setting would only messup testing of packages while developing this extension (that setting would cause to use `dev-master` when testing instead of proper versions and I believe was set there by accident by someone who didn't understand it's meaning).

This is for #16 issue which would then be really closed as I've verified everything now.

