### PR TITLE
ErrorExtension: Rename ErrorObserver interface to ErrorObserverInterface + Update PhpSpecExtension

### DIFF
--- a/src/Extension/ErrorExtension/README.md
+++ b/src/Extension/ErrorExtension/README.md
@@ -42,19 +42,23 @@ default:
 Error Observers
 ---------------
 
-Observers can be registered for the errors to handle them in some way from another Behat extension.
-These must implement the following interface:
+Observers can be registered for the errors to handle them in some way from
+another Behat extension. Observers must implement
+`RMiller\BehatSpec\Extensions\ErrorExtensions\Observer\ErrorObserverInterface`
+and be tagged with `rmiller.error_listener` tag in the service configuration.
+
+Example of a custom error observer:
 
 ```php
-namespace RMiller\BehatSpec\Extension\ErrorExtension\Observer;
+use RMiller\BehatSpec\Extension\ErrorExtension\Observer\ErrorObserverInterface;
 
-interface ErrorObserver
+class CustomErrorObserver implements ErrorObserverInterface
 {
-    public function notify(array $error);
+    public function notify(array $error) {
+        // observer notify method implementation
+    }
 }
 ```
-
-and be tagged with `rmiller.error_listener` in the service configuration.
 
 Currently this is used by the [PhpSpecExtension](https://github.com/richardmiller/PhpSpecExtension)
 to trigger running PhpSpec commands on relevant errors.

--- a/src/Extension/ErrorExtension/spec/Observer/ErrorObserversSpec.php
+++ b/src/Extension/ErrorExtension/spec/Observer/ErrorObserversSpec.php
@@ -4,7 +4,7 @@ namespace spec\RMiller\BehatSpec\Extension\ErrorExtension\Observer;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use RMiller\BehatSpec\Extension\ErrorExtension\Observer\ErrorObserver;
+use RMiller\BehatSpec\Extension\ErrorExtension\Observer\ErrorObserverInterface;
 
 class ErrorObserversSpec extends ObjectBehavior
 {
@@ -13,7 +13,7 @@ class ErrorObserversSpec extends ObjectBehavior
         $this->shouldThrow('\InvalidArgumentException')->during('__construct', [[new \stdClass()]]);
     }
 
-    function it_can_be_constructed_with_observers(ErrorObserver $observer)
+    function it_can_be_constructed_with_observers(ErrorObserverInterface $observer)
     {
         $this->beConstructedWith([$observer]);
     }

--- a/src/Extension/ErrorExtension/src/Observer/ErrorObserverInterface.php
+++ b/src/Extension/ErrorExtension/src/Observer/ErrorObserverInterface.php
@@ -4,7 +4,7 @@ namespace RMiller\BehatSpec\Extension\ErrorExtension\Observer;
 
 use Behat\Testwork\Call\Exception\FatalThrowableError;
 
-interface ErrorObserver
+interface ErrorObserverInterface
 {
     public function notify(FatalThrowableError $error);
 }

--- a/src/Extension/ErrorExtension/src/Observer/ErrorObservers.php
+++ b/src/Extension/ErrorExtension/src/Observer/ErrorObservers.php
@@ -9,11 +9,11 @@ class ErrorObservers implements \IteratorAggregate
     public function __construct(array $observers = [])
     {
         foreach ($observers as $observer) {
-            if ($observer instanceof ErrorObserver) {
+            if ($observer instanceof ErrorObserverInterface) {
                 continue;
             }
 
-            $message = 'Can only be constructed with implementations of RMiller\BehatSpec\Extension\ErrorExtension\Observer\ErrorObserver';
+            $message = 'Can only be constructed with implementations of RMiller\BehatSpec\Extension\ErrorExtension\Observer\ErrorObserverInterface';
             throw new \InvalidArgumentException($message);
         }
 

--- a/src/Extension/ErrorExtension/src/Observer/ErrorObservers.php
+++ b/src/Extension/ErrorExtension/src/Observer/ErrorObservers.php
@@ -13,7 +13,7 @@ class ErrorObservers implements \IteratorAggregate
                 continue;
             }
 
-            $message = 'Can only be constructed with implementations of RMiller\BehatSpec\Extension\ErrorExtension\Observer\ErrorObserverInterface';
+            $message = 'Can only be constructed with implementations of ' . ErrorObserverInterface::class;
             throw new \InvalidArgumentException($message);
         }
 

--- a/src/Extension/PhpSpecExtension/src/ErrorObserver/MissingMethodErrorObserver.php
+++ b/src/Extension/PhpSpecExtension/src/ErrorObserver/MissingMethodErrorObserver.php
@@ -3,10 +3,10 @@
 namespace RMiller\BehatSpec\Extension\PhpSpecExtension\ErrorObserver;
 
 use Behat\Testwork\Call\Exception\FatalThrowableError;
-use RMiller\BehatSpec\Extension\ErrorExtension\Observer\ErrorObserver;
+use RMiller\BehatSpec\Extension\ErrorExtension\Observer\ErrorObserverInterface;
 use RMiller\BehatSpec\Extension\PhpSpecExtension\Process\ExemplifyRunner;
 
-class MissingMethodErrorObserver implements ErrorObserver
+class MissingMethodErrorObserver implements ErrorObserverInterface
 {
     private $exemplifyRunner;
 


### PR DESCRIPTION
- Rename ErrorObserver interface to ErrorObserverInterface
- Update PhpSpecExtension

Fixes #34 